### PR TITLE
Full media endpoint support

### DIFF
--- a/examples/example.nim
+++ b/examples/example.nim
@@ -9,30 +9,30 @@ when isMainModule:
                                  parsed["AccessToken"].str,
                                  parsed["AccessTokenSecret"].str)
 
-  # Simply get.
-  var resp = twitterAPI.get("account/verify_credentials.json")
-  echo resp.status
+  # # Simply get.
+  # var resp = twitterAPI.get("account/verify_credentials.json")
+  # echo resp.status
 
-  # ditto, but selected by screen name.
-  resp = twitterAPI.user("sn_fk_n")
-  echo pretty parseJson(resp.body)
+  # # ditto, but selected by screen name.
+  # resp = twitterAPI.user("sn_fk_n")
+  # echo pretty parseJson(resp.body)
 
-  # Using proc corresponding twitter REST APIs.
-  resp = twitterAPI.userTimeline()
-  echo pretty parseJson(resp.body)
+  # # Using proc corresponding twitter REST APIs.
+  # resp = twitterAPI.userTimeline()
+  # echo pretty parseJson(resp.body)
 
-  # Using `callAPI` template.
-  var testStatus = {"status": "test"}.newStringTable
-  resp = twitterAPI.callAPI(statusesUpdate, testStatus)
-  echo pretty parseJson(resp.body)
+  # # Using `callAPI` template.
+  # var testStatus = {"status": "test"}.newStringTable
+  # resp = twitterAPI.callAPI(statusesUpdate, testStatus)
+  # echo pretty parseJson(resp.body)
 
   # Upload files in a stream
   const buffersize = 500000
-  let mediaStream = newFileStream("test.mp4", fmRead)
-  let mediaSize = "test.mp4".getFileSize
+  let mediaStream = newFileStream("test.jpg", fmRead)
+  let mediaSize = "test.jpg".getFileSize
 
   # INIT
-  resp = twitterAPI.mediaUploadInit("video/mp4", $ mediaSize)
+  var resp = twitterAPI.mediaUploadInit("image/jpg", $ mediaSize)
   let initResp = parseJson(resp.body)
   echo pretty initResp
   let mediaId = initResp["media_id_string"].getStr
@@ -48,7 +48,7 @@ when isMainModule:
       # Response should be 204
       if resp.status != "204 No Content":
         stderr.writeLine "Error when uploading, server returned: " & resp.status
-        break
+        quit(1)
       segment += 1
 
   # FINALIZE
@@ -76,7 +76,12 @@ when isMainModule:
     if respBody["processing_info"]["state"].getStr == "failed":
       stderr.writeLine("Processing failed, perhaps your video was in the wrong format")
 
+  # Attach metadata
+  let mediaMetadata = %* {"media_id": mediaId, "alt_text":{"text":"This is an example of alt text"}}
+  resp = twitterAPI.mediaMetadataCreate(mediaMetadata)
+  # This should be 2xx
+  echo resp.status
   
   # Send a tweet with that media
-  var mediaStatus = {"status": "This is an media upload test", "media_ids": finalMediaId}.newStringTable
+  let mediaStatus = {"status": "This is an media upload test", "media_ids": finalMediaId}.newStringTable
   resp = twitterAPI.statusesUpdate(mediaStatus)

--- a/twitter.nim
+++ b/twitter.nim
@@ -334,6 +334,20 @@ proc mediaMetadataCreate*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
   return post(twitter, "media/metadata/create.json", jsonBody, media=true)
 
 
+proc mediaSubtitlesCreate*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
+  ## `media/subtitles/create.json` endpoint
+  ##
+  ## Docs: https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-subtitles-create
+  return post(twitter, "media/subtitles/create.json", jsonBody, media=true)
+
+
+proc mediaSubtitlesDelete*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
+  ## `media/subtitles/delete.json` endpoint
+  ##
+  ## Docs: https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-subtitles-create
+  return post(twitter, "media/subtitles/delete.json", jsonBody, media=true)
+
+
 template callAPI*(twitter: TwitterAPI, api: untyped,
                   additionalParams: StringTableRef = nil): untyped =
   ## Template to callAPI

--- a/twitter.nim
+++ b/twitter.nim
@@ -12,7 +12,7 @@ import json
 
 const baseUrl = "https://api.twitter.com/1.1/"
 const uploadUrl = "https://upload.twitter.com/1.1/"
-const clientUserAgent = "twitter.nim/0.2.5"
+const clientUserAgent = "twitter.nim/0.3.0"
 
 
 type

--- a/twitter.nim
+++ b/twitter.nim
@@ -228,7 +228,6 @@ proc uploadFile*(twitter: TwitterAPI, filename: string,
   let data = $ readFile(filename)
   return post(twitter, "media/upload.json", ubody, true, data)
 
-
 proc mediaUploadInit*(twitter: TwitterAPI, 
                       mediaType: string, totalBytes: string, 
                       additionalParams: StringTableRef = nil): Response =
@@ -239,13 +238,13 @@ proc mediaUploadInit*(twitter: TwitterAPI,
   ##
   ## The response returned from this will contain a media_id field that you
   ## need to provide to the other `mediaUpload` procs
-  var ubody = newStringTable()
   if additionalParams != nil:
-    ubody = additionalParams
-  ubody["command"] = "INIT"
-  ubody["media_type"] = mediaType
-  ubody["total_bytes"] = totalBytes
-  return post(twitter, "media/upload.json", ubody, true)
+    additionalParams["command"] = "INIT"
+    additionalParams["media_type"] = mediaType
+    additionalParams["total_bytes"] = totalBytes
+    return post(twitter, "media/upload.json", additionalParams, true)
+  else:
+    return post(twitter, "media/upload.json", {"command":"INIT", "media_type":mediaType, "total_bytes":totalBytes}.newStringTable, true)
 
 
 proc mediaUploadAppend*(twitter: TwitterAPI, mediaId: string, segmentId: string,
@@ -254,13 +253,13 @@ proc mediaUploadAppend*(twitter: TwitterAPI, mediaId: string, segmentId: string,
   ## See: https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload-append
   ##
   ## Appends a chunk of data to a media upload, can accept base64 or binary
-  var ubody = newStringTable()
   if additionalParams != nil:
-    ubody = additionalParams
-  ubody["command"] = "APPEND"
-  ubody["media_id"] = mediaId
-  ubody["segment_index"] = segmentId
-  return post(twitter, "media/upload.json", ubody, true, data)
+    additionalParams["command"] = "APPEND"
+    additionalParams["media_id"] = mediaId
+    additionalParams["segment_index"] = segmentId
+    return post(twitter, "media/upload.json", additionalParams, true, data)
+  else:
+    return post(twitter, "media/upload.json", {"command":"APPEND", "media_id":mediaId, "segment_id":segmentId}.newStringTable, true, data)
 
 
 proc mediaUploadStatus*(twitter: TwitterAPI, mediaId: string,
@@ -271,12 +270,12 @@ proc mediaUploadStatus*(twitter: TwitterAPI, mediaId: string,
   ## Used to check the processing status of an upload. This should only be run
   ## when mediaUploadFinalize_ returns a `processing_info` field otherwise a
   ## 404 will be generated
-  var ubody = newStringTable()
   if additionalParams != nil:
-    ubody = additionalParams
-  ubody["command"] = "STATUS"
-  ubody["media_id"] = mediaId
-  return get(twitter, "media/upload.json", ubody, true)
+    additionalParams["command"] = "STATUS"
+    additionalParams["media_id"] = mediaId
+    return get(twitter, "media/upload.json", additionalParams, true)
+  else:
+    return get(twitter, "media/upload.json", {"command":"STATUS", "media_id":mediaId}.newStringTable, true)
 
 
 proc mediaUploadFinalize*(twitter: TwitterAPI, mediaId: string,
@@ -287,12 +286,12 @@ proc mediaUploadFinalize*(twitter: TwitterAPI, mediaId: string,
   ## Used to tell twitter your upload is finished. Will return a response
   ## with a `processing_info` field if further processing needs to be done use
   ## mediaUploadStatus_ to poll until completion.
-  var ubody = newStringTable()
   if additionalParams != nil:
-    ubody = additionalParams
-  ubody["command"] = "FINALIZE"
-  ubody["media_id"] = mediaId
-  return post(twitter, "media/upload.json", ubody, true)
+    additionalParams["command"] = "FINALIZE"
+    additionalParams["media_id"] = mediaId
+    return post(twitter, "media/upload.json", additionalParams, true)
+  else:
+    return post(twitter, "media/upload.json", {"command":"FINALIZE", "media_id":mediaId}.newStringTable, true)
 
 
 template callAPI*(twitter: TwitterAPI, api: untyped,

--- a/twitter.nim
+++ b/twitter.nim
@@ -141,7 +141,6 @@ proc request*(twitter: TwitterAPI, endPoint: string, jsonBody: JsonNode = nil,
   let url = requestUrl & endPoint
   var keys: seq[string] = @[]
 
-  # TODO HOW TO AUTH WITH JSON BODY
   var params = buildParams(twitter.consumerToken.consumerKey,
                            twitter.accessToken)
   params["oauth_signature"] = signature(twitter.consumerToken.consumerSecret,

--- a/twitter.nimble
+++ b/twitter.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.2.5"
+version = "0.3.0"
 author = "snus-kin"
 description = "A twitter API wrapper for Nim."
 license = "MIT"


### PR DESCRIPTION
With this pull:
- GET media/upload (STATUS)
- POST media/metadata/create
- POST media/subtitles/create
- POST media/subtitles/delete
- POST media/upload
- POST media/upload (APPEND)
- POST media/upload (FINALIZE)
- POST media/upload (INIT)

Endpoints are all supported and another `request()` proc is added to deal with requests with a json body