### PR TITLE
1.0.0 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 src/twitter
 examples/example
 examples/credential.json
-docs/*
 nimcache/
 *.swp
 twitter

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ examples/credential.json
 nimcache/
 *.swp
 twitter
+test.jpg
+test.mp4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 src/twitter
 examples/example
 examples/credential.json
+docs/*
 nimcache/
 *.swp
 twitter

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Jae Yang
+Copyright (c) 2020 Thomas Carroll
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ $ cd twitter.nim && nimble install
 ## Usage
 To use the library, `import twitter` and compile with `-d:ssl` 
 
-## Example
+Note: only the standard (free) endpoints are wrapped. All mentioned in the
+[API Reference Index](https://developer.twitter.com/en/docs/api-reference-index)
+have been implemented, please open an issue if you find one that isn't in this
+reference.
 
+## Example
 ```nim
 import twitter, json, strtabs
 
@@ -53,3 +57,5 @@ when isMainModule:
   resp = twitterAPI.post("media/upload.json", ubody, media=true, data=image)
   echo parseJson(resp.body)
 ```
+
+See also: `examples/` for more extensive examples on the library's use.

--- a/docs/twitter.html
+++ b/docs/twitter.html
@@ -136,23 +136,23 @@ function main() {
     title="post(twitter: TwitterAPI; endPoint: string; jsonBody: JsonNode; media: bool = false): Response"><wbr />post<span class="attachedType">TwitterAPI</span></a></li>
   <li><a class="reference" href="#statusesUpdate%2CTwitterAPI%2CStringTableRef"
     title="statusesUpdate(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />statuses<wbr />Update<span class="attachedType">TwitterAPI</span></a></li>
-  <li><a class="reference" href="#userTimeline%2CTwitterAPI%2CStringTableRef"
-    title="userTimeline(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />user<wbr />Timeline<span class="attachedType">TwitterAPI</span></a></li>
-  <li><a class="reference" href="#homeTimeline%2CTwitterAPI%2CStringTableRef"
-    title="homeTimeline(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />home<wbr />Timeline<span class="attachedType">TwitterAPI</span></a></li>
-  <li><a class="reference" href="#mentionsTimeline%2CTwitterAPI%2CStringTableRef"
-    title="mentionsTimeline(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />mentions<wbr />Timeline<span class="attachedType">TwitterAPI</span></a></li>
-  <li><a class="reference" href="#retweetsOfMe%2CTwitterAPI%2CStringTableRef"
-    title="retweetsOfMe(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />retweets<wbr />Of<wbr />Me<span class="attachedType">TwitterAPI</span></a></li>
-  <li><a class="reference" href="#user%2CTwitterAPI%2CStringTableRef"
-    title="user(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />user<span class="attachedType">TwitterAPI</span></a></li>
-  <li><a class="reference" href="#user%2CTwitterAPI%2Cstring%2CStringTableRef"
-    title="user(twitter: TwitterAPI; screenName: string; additionalParams: StringTableRef = nil): Response"><wbr />user<span class="attachedType">TwitterAPI</span></a></li>
-  <li><a class="reference" href="#user%2CTwitterAPI%2Cint32%2CStringTableRef"
-    title="user(twitter: TwitterAPI; userId: int32; additionalParams: StringTableRef = nil): Response"><wbr />user<span class="attachedType">TwitterAPI</span></a></li>
-  <li><a class="reference" href="#uploadFile%2CTwitterAPI%2Cstring%2Cstring%2CStringTableRef"
-    title="uploadFile(twitter: TwitterAPI; filename: string; mediaType: string;
-           additionalParams: StringTableRef = nil): Response"><wbr />upload<wbr />File<span class="attachedType">TwitterAPI</span></a></li>
+  <li><a class="reference" href="#statusesUserTimeline%2CTwitterAPI%2CStringTableRef"
+    title="statusesUserTimeline(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />statuses<wbr />User<wbr />Timeline<span class="attachedType">TwitterAPI</span></a></li>
+  <li><a class="reference" href="#statusesHomeTimeline%2CTwitterAPI%2CStringTableRef"
+    title="statusesHomeTimeline(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />statuses<wbr />Home<wbr />Timeline<span class="attachedType">TwitterAPI</span></a></li>
+  <li><a class="reference" href="#statusesMentionsTimeline%2CTwitterAPI%2CStringTableRef"
+    title="statusesMentionsTimeline(twitter: TwitterAPI;
+                         additionalParams: StringTableRef = nil): Response"><wbr />statuses<wbr />Mentions<wbr />Timeline<span class="attachedType">TwitterAPI</span></a></li>
+  <li><a class="reference" href="#statusesRetweetsOfMe%2CTwitterAPI%2CStringTableRef"
+    title="statusesRetweetsOfMe(twitter: TwitterAPI; additionalParams: StringTableRef = nil): Response"><wbr />statuses<wbr />Retweets<wbr />Of<wbr />Me<span class="attachedType">TwitterAPI</span></a></li>
+  <li><a class="reference" href="#accountVerifyCredentials%2CTwitterAPI%2CStringTableRef"
+    title="accountVerifyCredentials(twitter: TwitterAPI;
+                         additionalParams: StringTableRef = nil): Response"><wbr />account<wbr />Verify<wbr />Credentials<span class="attachedType">TwitterAPI</span></a></li>
+  <li><a class="reference" href="#usersShow%2CTwitterAPI%2Cstring%2CStringTableRef"
+    title="usersShow(twitter: TwitterAPI; screenName: string;
+          additionalParams: StringTableRef = nil): Response"><wbr />users<wbr />Show<span class="attachedType">TwitterAPI</span></a></li>
+  <li><a class="reference" href="#usersShow%2CTwitterAPI%2Cint32%2CStringTableRef"
+    title="usersShow(twitter: TwitterAPI; userId: int32; additionalParams: StringTableRef = nil): Response"><wbr />users<wbr />Show<span class="attachedType">TwitterAPI</span></a></li>
   <li><a class="reference" href="#mediaUploadInit%2CTwitterAPI%2Cstring%2Cstring%2CStringTableRef"
     title="mediaUploadInit(twitter: TwitterAPI; mediaType: string; totalBytes: string;
                 additionalParams: StringTableRef = nil): Response"><wbr />media<wbr />Upload<wbr />Init<span class="attachedType">TwitterAPI</span></a></li>
@@ -171,6 +171,9 @@ function main() {
     title="mediaSubtitlesCreate(twitter: TwitterAPI; jsonBody: JsonNode): Response"><wbr />media<wbr />Subtitles<wbr />Create<span class="attachedType">TwitterAPI</span></a></li>
   <li><a class="reference" href="#mediaSubtitlesDelete%2CTwitterAPI%2CJsonNode"
     title="mediaSubtitlesDelete(twitter: TwitterAPI; jsonBody: JsonNode): Response"><wbr />media<wbr />Subtitles<wbr />Delete<span class="attachedType">TwitterAPI</span></a></li>
+  <li><a class="reference" href="#uploadFile%2CTwitterAPI%2Cstring%2Cstring%2CStringTableRef"
+    title="uploadFile(twitter: TwitterAPI; filename: string; mediaType: string;
+           additionalParams: StringTableRef = nil): Response"><wbr />upload<wbr />File<span class="attachedType">TwitterAPI</span></a></li>
 
   </ul>
 </li>
@@ -189,7 +192,7 @@ function main() {
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
   
-  <p class="module-desc"></p>
+  <p class="module-desc">statuses ========users =====media =====</p>
   <div class="section" id="7">
 <h1><a class="toc-backref" href="#7">Types</a></h1>
 <dl class="item">
@@ -313,8 +316,9 @@ Overload for post that includes binary data e.g. images / video to upload
 <tt class="docutils literal"><span class="pre">statuses/update.json</span></tt> endpoint
 
 </dd>
-<a id="userTimeline,TwitterAPI,StringTableRef"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#userTimeline%2CTwitterAPI%2CStringTableRef"><span class="Identifier">userTimeline</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
+<a id="statusesUserTimeline,TwitterAPI,StringTableRef"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#statusesUserTimeline%2CTwitterAPI%2CStringTableRef"><span class="Identifier">statusesUserTimeline</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span>
+                         <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
     <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span>
     <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span>
     <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
@@ -323,8 +327,9 @@ Overload for post that includes binary data e.g. images / video to upload
 <tt class="docutils literal"><span class="pre">statuses/user_timeline.json</span></tt> endpoint
 
 </dd>
-<a id="homeTimeline,TwitterAPI,StringTableRef"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#homeTimeline%2CTwitterAPI%2CStringTableRef"><span class="Identifier">homeTimeline</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
+<a id="statusesHomeTimeline,TwitterAPI,StringTableRef"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#statusesHomeTimeline%2CTwitterAPI%2CStringTableRef"><span class="Identifier">statusesHomeTimeline</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span>
+                         <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
     <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span>
     <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span>
     <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
@@ -333,8 +338,9 @@ Overload for post that includes binary data e.g. images / video to upload
 <tt class="docutils literal"><span class="pre">statuses/home_timeline.json</span></tt> endpoint
 
 </dd>
-<a id="mentionsTimeline,TwitterAPI,StringTableRef"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#mentionsTimeline%2CTwitterAPI%2CStringTableRef"><span class="Identifier">mentionsTimeline</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
+<a id="statusesMentionsTimeline,TwitterAPI,StringTableRef"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#statusesMentionsTimeline%2CTwitterAPI%2CStringTableRef"><span class="Identifier">statusesMentionsTimeline</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span>
+                             <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
     <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span>
     <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span>
     <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
@@ -343,8 +349,9 @@ Overload for post that includes binary data e.g. images / video to upload
 <tt class="docutils literal"><span class="pre">statuses/mentions_timeline.json</span></tt> endpoint
 
 </dd>
-<a id="retweetsOfMe,TwitterAPI,StringTableRef"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#retweetsOfMe%2CTwitterAPI%2CStringTableRef"><span class="Identifier">retweetsOfMe</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
+<a id="statusesRetweetsOfMe,TwitterAPI,StringTableRef"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#statusesRetweetsOfMe%2CTwitterAPI%2CStringTableRef"><span class="Identifier">statusesRetweetsOfMe</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span>
+                         <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
     <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span>
     <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span>
     <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
@@ -353,8 +360,9 @@ Overload for post that includes binary data e.g. images / video to upload
 <tt class="docutils literal"><span class="pre">statuses/retweets_of_me.json</span></tt> endpoint
 
 </dd>
-<a id="user,TwitterAPI,StringTableRef"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#user%2CTwitterAPI%2CStringTableRef"><span class="Identifier">user</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
+<a id="accountVerifyCredentials,TwitterAPI,StringTableRef"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#accountVerifyCredentials%2CTwitterAPI%2CStringTableRef"><span class="Identifier">accountVerifyCredentials</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span>
+                             <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
     <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span>
     <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span>
     <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
@@ -363,36 +371,24 @@ Overload for post that includes binary data e.g. images / video to upload
 <tt class="docutils literal"><span class="pre">account/verify_credentials.json</span></tt> endpoint
 
 </dd>
-<a id="user,TwitterAPI,string,StringTableRef"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#user%2CTwitterAPI%2Cstring%2CStringTableRef"><span class="Identifier">user</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">screenName</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
-         <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">,</span>
-    <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span> <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">TimeoutError</span><span class="Other">,</span>
-    <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<a id="usersShow,TwitterAPI,string,StringTableRef"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#usersShow%2CTwitterAPI%2Cstring%2CStringTableRef"><span class="Identifier">usersShow</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">screenName</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
+              <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">OSError</span><span class="Other">,</span>
+    <span class="Identifier">IOError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span> <span class="Identifier">Exception</span><span class="Other">,</span>
+    <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
 <dd>
 
 <tt class="docutils literal"><span class="pre">users/show.json</span></tt> endpoint for screen names (@username)
 
 </dd>
-<a id="user,TwitterAPI,int32,StringTableRef"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#user%2CTwitterAPI%2Cint32%2CStringTableRef"><span class="Identifier">user</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">userId</span><span class="Other">:</span> <span class="Identifier">int32</span><span class="Other">;</span> <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span>
-    <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span>
-    <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span>
-    <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
-<dd>
-
-<tt class="docutils literal"><span class="pre">users/show.json</span></tt> endpoint for user id (e.g. <tt class="docutils literal"><span class="pre">783214 =&gt; @twitter</span></tt>)
-
-</dd>
-<a id="uploadFile,TwitterAPI,string,string,StringTableRef"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#uploadFile%2CTwitterAPI%2Cstring%2Cstring%2CStringTableRef"><span class="Identifier">uploadFile</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">filename</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">mediaType</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
-               <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">IOError</span><span class="Other">,</span>
-    <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span> <span class="Identifier">Exception</span><span class="Other">,</span>
+<a id="usersShow,TwitterAPI,int32,StringTableRef"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#usersShow%2CTwitterAPI%2Cint32%2CStringTableRef"><span class="Identifier">usersShow</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">userId</span><span class="Other">:</span> <span class="Identifier">int32</span><span class="Other">;</span>
+              <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">OSError</span><span class="Other">,</span>
+    <span class="Identifier">IOError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span> <span class="Identifier">Exception</span><span class="Other">,</span>
     <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
 <dd>
 
-<p>Upload a file from a filename</p>
-<p>mediaType takes these arguments: <tt class="docutils literal"><span class="pre">amplify_video, tweet_gif, tweet_image, tweet_video</span></tt></p>
-
+<tt class="docutils literal"><span class="pre">users/show.json</span></tt> endpoint for user id (e.g. <tt class="docutils literal"><span class="pre">783214 =&gt; @twitter</span></tt>)
 
 </dd>
 <a id="mediaUploadInit,TwitterAPI,string,string,StringTableRef"></a>
@@ -488,6 +484,18 @@ Overload for post that includes binary data e.g. images / video to upload
 
 
 </dd>
+<a id="uploadFile,TwitterAPI,string,string,StringTableRef"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#uploadFile%2CTwitterAPI%2Cstring%2Cstring%2CStringTableRef"><span class="Identifier">uploadFile</span></a><span class="Other">(</span><span class="Identifier">twitter</span><span class="Other">:</span> <a href="twitter.html#TwitterAPI"><span class="Identifier">TwitterAPI</span></a><span class="Other">;</span> <span class="Identifier">filename</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span> <span class="Identifier">mediaType</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
+               <span class="Identifier">additionalParams</span><span class="Other">:</span> <span class="Identifier">StringTableRef</span> <span class="Other">=</span> <span class="Keyword">nil</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">Response</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">IOError</span><span class="Other">,</span>
+    <span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">KeyError</span><span class="Other">,</span> <span class="Identifier">ValueError</span><span class="Other">,</span> <span class="Identifier">HttpRequestError</span><span class="Other">,</span> <span class="Identifier">SslError</span><span class="Other">,</span> <span class="Identifier">Defect</span><span class="Other">,</span> <span class="Identifier">Exception</span><span class="Other">,</span>
+    <span class="Identifier">TimeoutError</span><span class="Other">,</span> <span class="Identifier">ProtocolError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+<p>Upload a file from a filename</p>
+<p>mediaType takes these arguments: <tt class="docutils literal"><span class="pre">amplify_video, tweet_gif, tweet_image, tweet_video</span></tt></p>
+
+
+</dd>
 
 </dl></div>
 <div class="section" id="18">
@@ -514,7 +522,7 @@ Overload for post that includes binary data e.g. images / video to upload
       <div class="twelve-columns footer">
         <span class="nim-sprite"></span>
         <br/>
-        <small style="color: var(--hint);">Made with Nim. Generated: 2020-07-24 15:08:22 UTC</small>
+        <small style="color: var(--hint);">Made with Nim. Generated: 2020-07-24 17:15:57 UTC</small>
       </div>
     </div>
   </div>

--- a/twitter.nim
+++ b/twitter.nim
@@ -326,7 +326,30 @@ proc statusesRetweetsOfMe*(twitter: TwitterAPI,
 # ---------------
 # custom_profiles
 # ---------------
-# TODO
+
+
+proc customProfilesDestroy*(twitter:TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `custom_profiles/destroy.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return delete(twitter, "custom_profiles/destroy.json", additionalParams)
+  else:
+    return delete(twitter, "custom_profiles/destroy.json", {"id": $id}.newStringTable)
+
+
+proc customProfilesId*(twitter:TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response = 
+  ## `custom_profiles/:id.json` endpoint
+  return get(twitter, "custom_profiles/" & $id & ".json", additionalParams)
+
+
+proc customProfilesLists*(twitter:TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `custom_profiles/list.json` endpoint
+  return get(twitter, "custom_profiles/list.json", additionalParams)
+
+
+proc customProfilesNew*(twitter:TwitterAPI, jsonBody: JsonNode): Response =
+  ## `custom_profiles/new.json` endpoint
+  return post(twitter, "custom_profiles/new.json", jsonBody)
 
 
 # ---------------

--- a/twitter.nim
+++ b/twitter.nim
@@ -282,8 +282,11 @@ proc accountVerifyCredentials*(twitter: TwitterAPI,
 # --------
 # statuses
 # --------
-# TODO
 
+
+proc statusesFilter*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `statuses/filter.json` endpoint
+  return post(twitter, "statuses/filter.json", additionalParams)
 
 
 proc statusesUserTimeline*(twitter: TwitterAPI,

--- a/twitter.nim
+++ b/twitter.nim
@@ -225,6 +225,171 @@ proc put*(twitter: TwitterAPI, endPoint: string,
 # ---------------------------------
 # TODO
 
+proc followersIds*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `followers/ids.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "followers/ids.json", additionalParams)
+  else:
+    return get(twitter, "followers/ids.json", {"screen_name": screenName}.newStringTable)
+
+
+proc followersIds*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `followers/id.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "followers/ids.json", additionalParams)
+  else:
+    return get(twitter, "followers/ids.json", {"user_id": $userId}.newStringTable)
+
+
+proc followersList*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `followers/list.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "followers/list.json", additionalParams)
+  else:
+    return get(twitter, "followers/list.json", {"screen_name": screenName}.newStringTable)
+
+
+proc followersList*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `followers/list.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "followers/list.json", additionalParams)
+  else:
+    return get(twitter, "followers/list.json", {"user_id": $userId}.newStringTable)
+
+
+proc friendsIds*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `friends/ids.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "friends/ids.json", additionalParams)
+  else:
+    return get(twitter, "friends/ids.json", {"screen_name": screenName}.newStringTable)
+
+
+proc friendsIds*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `friends/id.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "friends/ids.json", additionalParams)
+  else:
+    return get(twitter, "friends/ids.json", {"user_id": $userId}.newStringTable)
+
+
+proc friendsList*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `friends/list.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "friends/list.json", additionalParams)
+  else:
+    return get(twitter, "friends/list.json", {"screen_name": screenName}.newStringTable)
+
+
+proc friendsList*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `friends/list.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "friends/list.json", additionalParams)
+  else:
+    return get(twitter, "friends/list.json", {"user_id": $userId}.newStringTable)
+
+
+proc friendshipsIncoming*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/incoming.json` endpoint
+  return get(twitter, "friendships/incoming.json", additionalParams)
+
+
+proc friendshipsLookup*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/lookup.json` endpoint
+  return get(twitter, "friendships/lookup.json", additionalParams)
+
+
+proc friendshipsNoRetweetsIds*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/no_retweets/ids.json`
+  return get(twitter, "friendships/no_retweets/ids.json", additionalParams)
+
+
+proc friendshipsOutgoing*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/outgoing.json` endpoint
+  return get(twitter, "friendships/outgoing.json", additionalParams)
+
+
+proc friendshipsShow*(twitter: TwitterAPI, sourceId: int, targetId: int, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/show.json` endpoint
+  if additionalParams != nil:
+    additionalParams["source_id"] = $sourceId
+    additionalParams["target_id"] = $targetId
+    return get(twitter, "friendships/show.json", additionalParams)
+  else:
+    return get(twitter, "friendships/show.json", {"source_id": $sourceId, "target_id": $targetId}.newStringTable)
+
+
+proc friendshipsShow*(twitter: TwitterAPI, sourceScreenName: string, targetScreenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/show.json` endpoint
+  if additionalParams != nil:
+    additionalParams["source_screen_name"] = sourceScreenName
+    additionalParams["target_screen_name"] = targetScreenName
+    return get(twitter, "friendships/show.json", additionalParams)
+  else:
+    return get(twitter, "friendships/show.json", {"source_screen_name": sourceScreenName, "target_screen_name": targetScreenName}.newStringTable)
+
+
+proc friendshipsCreate*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/create.json` endpoint
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return post(twitter, "friendships/create.json", additionalParams)
+  else:
+    return post(twitter, "friendships/create.json", {"screen_name": screenName}.newStringTable)
+
+
+proc friendshipsCreate*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/create.json` endpoint
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return post(twitter, "friendships/create.json", additionalParams)
+  else:
+    return post(twitter, "friendships/create.json", {"user_id": $userId}.newStringTable)
+
+
+proc friendshipsDestroy*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/destroy.json` endpoint
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return post(twitter, "friendships/destroy.json", additionalParams)
+  else:
+    return post(twitter, "friendships/destroy.json", {"screen_name": screenName}.newStringTable)
+
+
+proc friendshipsDestroy*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/destroy.json` endpoint
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return post(twitter, "friendships/destroy.json", additionalParams)
+  else:
+    return post(twitter, "friendships/destroy.json", {"user_id": $userId}.newStringTable)
+
+
+proc friendshipsUpdate*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/update.json` endpoint
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return post(twitter, "friendships/update.json", additionalParams)
+  else:
+    return post(twitter, "friendships/update.json", {"screen_name": screenName}.newStringTable)
+
+
+proc friendshipsUpdate*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `friendships/update.json` endpoint
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return post(twitter, "friendships/update.json", additionalParams)
+  else:
+    return post(twitter, "friendships/update.json", {"user_id": $userId}.newStringTable)
+
 
 # -----
 # users

--- a/twitter.nim
+++ b/twitter.nim
@@ -231,6 +231,23 @@ proc put*(twitter: TwitterAPI, endPoint: string,
 # -----
 # TODO
 
+proc usersProfileBanner*(twitter:TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `users/profile_banner.json` endpoint
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "users/profile_banner.json", additionalParams)
+  else:
+    return get(twitter, "users/profile_banner.json", {"screen_name": screenName}.newStringTable)
+
+
+proc usersProfileBanner*(twitter:TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `users/profile_banner.json` endpoint
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "users/profile_banner.json", additionalParams)
+  else:
+    return get(twitter, "users/profile_banner.json", {"user_id": $userId}.newStringTable)
+
 
 proc usersShow*(twitter: TwitterAPI, screenName: string,
            additionalParams: StringTableRef = nil): Response =
@@ -275,16 +292,55 @@ proc usersReportSpam*(twitter: TwitterAPI, userId: int, additionalParams: String
 # -------
 # TODO
 
+
+proc accountSettings*(twitter:TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `account/settings.json` endpoint
+  return get(twitter, "account/settings.json", additionalParams)
+
+
 proc accountVerifyCredentials*(twitter: TwitterAPI,
            additionalParams: StringTableRef = nil): Response =
   ## `account/verify_credentials.json` endpoint
   return get(twitter, "account/verify_credentials.json", additionalParams)
 
 
+proc accountRemoveProfileBanner*(twitter:TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `account/remove_profile_banner.json` endpoint
+  return post(twitter, "account/remove_profile_banner.json", additionalParams)
+
+
+proc accountUpdateSettings*(twitter:TwitterAPI, additionalParams: StringTableRef): Response =
+  ## `account/update_settings.json` endpoint
+  return post(twitter, "account/update_settings.json", additionalParams)
+
+
+proc accountUpdateProfile*(twitter:TwitterAPI, additionalParams: StringTableRef): Response =
+  ## `account/update_profile.json` endpoint
+  return post(twitter, "account/update_profile.json", additionalParams)
+
+
+proc accountUpdateProfileBanner*(twitter: TwitterAPI, banner: string, additionalParams: StringTableRef = nil): Response =
+  ## `account/update_profile_banner.json` endpoint
+  if additionalParams != nil:
+    additionalParams["banner"] = banner
+    return post(twitter, "account/update_profile_banner.json", additionalParams)
+  else:
+    return post(twitter, "account/update_profile_banner.json", {"banner": banner}.newStringTable)
+
+
+proc accountUpdateProfileImage*(twitter: TwitterAPI, image: string, additionalParams: StringTableRef = nil): Response =
+  ## `account/update_profile_image.json` endpoint
+  if additionalParams != nil:
+    additionalParams["image"] = image
+    return post(twitter, "account/update_profile_image.json", additionalParams)
+  else:
+    return post(twitter, "account/update_profile_image.json", {"image": image}.newStringTable)
+
+
 # --------------
 # saved_searches
 # --------------
-#TODO
+
 
 proc savedSeachesList*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
   ## `saved_searches/list.json` endpoint
@@ -308,6 +364,7 @@ proc savedSearchesCreate*(twitter: TwitterAPI, query: string, additionalParams: 
 proc savedSeachesDestroy*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
   ## `saved_searches/destroy/:id.json` endpoint
   return post(twitter, "saved_searches/destroy/" & $id & ".json", additionalParams)
+
 
 # --------------
 # blocks / mutes

--- a/twitter.nim
+++ b/twitter.nim
@@ -133,6 +133,8 @@ proc request*(twitter: TwitterAPI, endPoint, httpMethod: string,
     return httpclient.post(client, url & "?" & path)
   elif httpMethod == "DELETE":
     return httpclient.delete(client, url & "?" & path)
+  elif httpMethod == "PUT":
+    return httpclient.put(client, url & "?" & path)
 
 
 proc request*(twitter: TwitterAPI, endPoint: string, jsonBody: JsonNode = nil,
@@ -195,6 +197,12 @@ proc post*(twitter: TwitterAPI, endPoint: string,
 proc delete*(twitter: TwitterAPI, endPoint: string, 
              additionalParams: StringTableRef = nil): Response = 
   return request(twitter, endPoint, "DELETE", additionalParams)
+
+
+proc put*(twitter: TwitterAPI, endPoint: string, 
+             additionalParams: StringTableRef = nil): Response = 
+  return request(twitter, endPoint, "PUT", additionalParams)
+
 
 # --------------
 # authentication
@@ -326,6 +334,72 @@ proc statusesRetweetsOfMe*(twitter: TwitterAPI,
 # ---------------
 # TODO
 
+
+proc directMessagesWelcomeMessagesDestroy*(twitter: TwitterAPI, id: int,
+                                           additionalParams: StringTableRef = nil): Response = 
+  ## `direct_messages/welcome_messages/destroy.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return delete(twitter, "direct_messages/welcome_messages/destroy.json", additionalParams)
+  else:
+    return delete(twitter, "direct_messages/welcome_messages/destroy.json", {"id": $id}.newStringTable)
+
+
+proc directMessagesWelcomeMessagesRulesDestroy*(twitter: TwitterAPI, id: int,
+                                           additionalParams: StringTableRef = nil): Response = 
+  ## `direct_messages/welcome_messages/rules/destroy.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return delete(twitter, "direct_messages/rules/welcome_messages/destroy.json", additionalParams)
+  else:
+    return delete(twitter, "direct_messages/rules/welcome_messages/destroy.json", {"id": $id}.newStringTable)
+
+
+proc directMessagesWelcomeMessagesUpdate*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `direct_messages/welcome_messages/update.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return put(twitter, "direct_messages/welcome_messages/update.json", additionalParams)
+  else:
+    return put(twitter, "direct_messages/welcome_messages/update.json", {"id": $id}.newStringTable)
+
+
+proc directMessagesWelcomeMessagesList*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `direct_messages/welcome_messages/list.json` endpoint
+  return get(twitter, "direct_messages/welcome_messages/list.json", additionalParams)
+
+
+proc directMessagesWelcomeMessagesRulesList*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `direct_messages/welcome_messages/rules/list.json` endpoint
+  return get(twitter, "direct_messages/welcome_messages/rules/list.json", additionalParams)
+
+
+proc directMessagesWelcomeMessagesRulesShow*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `direct_messages/welcome_messages/rules/show.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $ id
+    return get(twitter, "direct_messages/welcome_messages/rules/show.json", additionalParams)
+  else:
+    return get(twitter, "direct_messages/welcome_messages/rules/show.json", {"id": $id}.newStringTable)
+
+
+proc directMessagesWelcomeMessagesShow*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `direct_messages/welcome_messages/show.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $ id
+    return get(twitter, "direct_messages/welcome_messages/show.json", additionalParams)
+  else:
+    return get(twitter, "direct_messages/welcome_messages/show.json", {"id": $id}.newStringTable)
+
+
+proc directMessagesWelcomeMessagesNew*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
+  ## `direct_messages/welcome_messages/new.json` endpoint
+  return post(twitter, "direct_messages/welcome_messages/new.json", jsonBody)
+
+
+proc directMessagesWelcomeMessagesRulesNew*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
+  ## `direct_messages/welcome_messages/rules/new.json` endpoint
+  return post(twitter, "direct_messages/welcome_messages/rules/new.json", jsonBody)
 
 # -----
 # media

--- a/twitter.nim
+++ b/twitter.nim
@@ -314,13 +314,44 @@ proc statusesRetweetsOfMe*(twitter: TwitterAPI,
 # ---------
 # favorites
 # ---------
-# TODO
 
 
-# ----------
-# compliance
-# ----------
-# TODO
+proc favoritesList*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response = 
+  ## `favorites/list.json` endpoint
+  return get(twitter, "favorites/list.json", additionalParams)
+
+
+proc favoritesCreate*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `favorites/create.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return post(twitter, "favorites/create.json", additionalParams)
+  else:
+    return post(twitter, "favorites/create.json", {"id": $id}.newStringTable)
+
+
+proc favoritesDestroy*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `favorites/destroy.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return post(twitter, "favorites/destroy.json", additionalParams)
+  else:
+    return post(twitter, "favorites/destroy.json", {"id": $id}.newStringTable)
+
+# ------
+# search
+# ------
+
+
+proc searchTweets*(twitter:TwitterAPI, q: string, additionalParams: StringTableRef = nil): Response = 
+  ## `search/tweets.json` endpoint
+  ##
+  ## Standard tier search endpoint
+  if additionalParams != nil:
+    additionalParams["q"] = q
+    return get(twitter, "search/tweets.json", additionalParams)
+  else:
+    return get(twitter, "search/tweets.json", {"q": q}.newStringTable)
 
 
 # ---------------
@@ -355,6 +386,8 @@ proc customProfilesNew*(twitter:TwitterAPI, jsonBody: JsonNode): Response =
 # ---------------
 # direct_messages
 # ---------------
+
+
 proc directMessagesEventsDestroy*(twitter: TwitterAPI, id: int,
                                            additionalParams: StringTableRef = nil): Response = 
   ## `direct_messages/events/destroy.json` endpoint

--- a/twitter.nim
+++ b/twitter.nim
@@ -421,7 +421,31 @@ proc mediaSubtitlesDelete*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
 # ------
 # trends
 # ------
-# TODO
+
+
+proc trendsAvailable*(twitter:TwitterAPI, additionalParams: StringTableRef = nil): Response = 
+  ## `trends/available.json` endpoint
+  return get(twitter, "trends/available.json", additionalParams)
+
+
+proc trendsClosest*(twitter:TwitterAPI, lat: float, lon: float, additionalParams: StringTableRef = nil): Response = 
+  ## `trends/closest.json` endpoint
+  if additionalParams != nil:
+    additionalParams["lat"] = $ lat
+    additionalParams["lon"] = $ lon
+    return get(twitter, "trends/closest.json", additionalParams)
+  else:
+    return get(twitter, "trends/closest.json", {"lat": $lat, "lon": $lon}.newStringTable)
+
+
+proc trendsPlace*(twitter:TwitterAPI, id: int32, additionalParams: StringTableRef = nil): Response = 
+  ## `trends/place.json` endpoint
+  # id is explicitly int32 since it is Yahoo WOED which uses 32 bit ints
+  if additionalParams != nil:
+    additionalParams["id"] = $ id
+    return get(twitter, "trends/place.json", additionalParams)
+  else:
+    return get(twitter, "trends/place.json", {"id": $id}.newStringTable)
 
 
 # ---

--- a/twitter.nim
+++ b/twitter.nim
@@ -280,16 +280,38 @@ proc accountVerifyCredentials*(twitter: TwitterAPI,
   ## `account/verify_credentials.json` endpoint
   return get(twitter, "account/verify_credentials.json", additionalParams)
 
+
 # --------------
 # saved_searches
 # --------------
 #TODO
 
+proc savedSeachesList*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `saved_searches/list.json` endpoint
+  return get(twitter, "saved_searches/list.json", additionalParams)
+
+
+proc savedSearchesShow*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `saved_searches/show/:id.json` endpoint
+  return get(twitter, "saved_searches/show/" & $id & ".json", additionalParams)
+
+
+proc savedSearchesCreate*(twitter: TwitterAPI, query: string, additionalParams: StringTableRef = nil): Response =
+  ## `saved_searches/create.json` endpoint
+  if additionalParams != nil:
+    additionalParams["query"] = query
+    return post(twitter, "saved_searches/create.json", additionalParams)
+  else:
+    return post(twitter, "saved_searches/create.json", {"query": query}.newStringTable)
+
+
+proc savedSeachesDestroy*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `saved_searches/destroy/:id.json` endpoint
+  return post(twitter, "saved_searches/destroy/" & $id & ".json", additionalParams)
 
 # --------------
 # blocks / mutes
 # --------------
-#TODO
 
 
 proc blocksIds*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =

--- a/twitter.nim
+++ b/twitter.nim
@@ -32,6 +32,7 @@ type
   TwitterAPI* = ref TwitterAPIImpl ## \
     ## TwitterAPI token object with a `consumerToken`, `accessToken`, and `accessTokenSecret`
 
+
 proc newConsumerToken*(consumerKey, consumerSecret: string): ConsumerToken =
   return ConsumerToken(consumerKey: consumerKey,
                        consumerSecret: consumerSecret)
@@ -277,6 +278,105 @@ proc accountVerifyCredentials*(twitter: TwitterAPI,
 # collections
 # -----------
 # TODO
+
+
+proc collectionsEntries*(twitter:TwitterAPI, id: string, additionalParams: StringTableRef = nil): Response =
+  ## `collections/entries.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = id
+    return get(twitter, "collections/entries.json", additionalParams)
+  else:
+    return get(twitter, "collections/entries.json", {"id": id}.newStringTable)
+
+
+proc collectionsList*(twitter:TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response =
+  ## `collections/list.json` endpoint for twitter user id
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return get(twitter, "collections/list.json", additionalParams)
+  else:
+    return get(twitter, "collections/list.json", {"id": $id}.newStringTable)
+
+
+proc collectionsList*(twitter:TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `collections/list.json` for twitter user screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "collections/list.json", additionalParams)
+  else:
+    return get(twitter, "collections/list.json", {"screen_name": screenName}.newStringTable)
+
+
+proc collectionsShow*(twitter:TwitterAPI, id: string, additionalParams: StringTableRef = nil): Response =
+  ## `collections/show.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = id
+    return get(twitter, "collections/show.json", additionalParams)
+  else:
+    return get(twitter, "collections/show.json", {"id": id}.newStringTable)
+
+
+proc collectionsCreate*(twitter:TwitterAPI, name: string, additionalParams: StringTableRef = nil): Response =
+  ## `collections/create.json` endpoint
+  if additionalParams != nil:
+    additionalParams["name"] = name
+    return post(twitter, "collections/create.json", additionalParams)
+  else:
+    return post(twitter, "collections/create.json", {"name": name}.newStringTable)
+
+
+proc collectionsDestroy*(twitter: TwitterAPI, id: string, additionalParams: StringTableRef = nil): Response =
+  if additionalParams != nil:
+    additionalParams["id"] = id
+    return post(twitter, "collections/destroy.json", additionalParams)
+  else:
+    return post(twitter, "collections/destroy.json", {"id": id}.newStringTable)
+
+
+proc collectionsEntriesAdd*(twitter: TwitterAPI, id: string, tweet_id: int, additionalParams: StringTableRef = nil): Response =
+  ## `collections/entries/add.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = id
+    additionalParams["tweet_id"] = $tweet_id
+    return post(twitter, "collections/entries/add.json", additionalParams)
+  else:
+    return post(twitter, "collections/entries/add.json", {"id": id, "tweet_id": $tweet_id}.newStringTable)
+
+
+proc collectionsEntriesCurate*(twitter: TwitterAPI, jsonBody: JsonNode): Response = 
+  ## `collections/entries/curate.json` endpoint
+  # This is honestly one of the worst parts of the API docs. I can't work out what it does. 
+  return post(twitter, "collections/entries/curate.json", jsonBody)
+
+
+proc collectionsEntriesMove*(twitter: TwitterAPI, id: string, tweet_id: int, relative_to: int, additionalParams: StringTableRef = nil): Response =
+  ## `collections/entries/move.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = id
+    additionalParams["tweet_id"] = $tweet_id
+    additionalParams["relative_to"] = $relative_to
+    return post(twitter, "collections/entries/move.json", additionalParams)
+  else:
+    return post(twitter, "collections/entries/move.json", {"id": id, "tweet_id": $tweet_id, "relative_to": $relative_to}.newStringTable)
+
+
+proc collectionsEntriesRemove*(twitter: TwitterAPI, id: string, tweet_id: int, additionalParams: StringTableRef = nil): Response =
+  ## `collections/entries/remove.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = id
+    additionalParams["tweet_id"] = $tweet_id
+    return post(twitter, "collections/entries/remove.json", additionalParams)
+  else:
+    return post(twitter, "collections/entries/remove.json", {"id": id, "tweet_id": $tweet_id}.newStringTable)
+
+
+proc collectionsUpdate*(twitter: TwitterAPI, id: string, additionalParams: StringTableRef = nil): Response =
+  ## `collections/update.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = id
+    return post(twitter, "collections/update.json", additionalParams)
+  else:
+    return post(twitter, "collections/update.json", {"id": id}.newStringTable)
 
 
 # --------

--- a/twitter.nim
+++ b/twitter.nim
@@ -332,7 +332,44 @@ proc statusesRetweetsOfMe*(twitter: TwitterAPI,
 # ---------------
 # direct_messages
 # ---------------
-# TODO
+proc directMessagesEventsDestroy*(twitter: TwitterAPI, id: int,
+                                           additionalParams: StringTableRef = nil): Response = 
+  ## `direct_messages/events/destroy.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return delete(twitter, "direct_messages/events/destroy.json", additionalParams)
+  else:
+    return delete(twitter, "direct_messages/events/destroy.json", {"id": $id}.newStringTable)
+
+
+proc directMessagsEventsList*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `direct_messages/events/list.json` endpoint
+  return get(twitter, "direct_messages/events/list.json", additionalParams)
+
+
+proc directMessagesEventsShow*(twitter: TwitterAPI, id: int, additionalParams: StringTableRef = nil): Response = 
+  ## `direct_messages/events/show.json` endpoint
+  if additionalParams != nil:
+    additionalParams["id"] = $id
+    return get(twitter, "direct_messages/events/show.json", additionalParams)
+  else:
+    return get(twitter, "direct_messages/events/show.json", {"id": $id}.newStringTable)
+
+
+proc directMessagesEventsNew*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
+  ## `direct_messages/events/new.json` endpoint (message_create)
+  return post(twitter, "direct_messages/events/new.json", jsonBody)
+
+
+proc directMessagesIndicateTyping*(twitter: TwitterAPI, jsonBody: JsonNode): Response = 
+  ## `direct_messages/indicate_typing.json` endpoint
+  return post(twitter, "direct_messages/indicate_typing.json", jsonBody)
+
+
+#TODO TEST THIS
+proc directMessagesMarkRead*(twitter: TwitterAPI, jsonBody: JsonNode): Response = 
+  ## `direct_messages/mark_read.json` endpoint
+  return post(twitter, "direct_messages/mark_read.json", jsonBody)
 
 
 proc directMessagesWelcomeMessagesDestroy*(twitter: TwitterAPI, id: int,

--- a/twitter.nim
+++ b/twitter.nim
@@ -211,8 +211,58 @@ proc put*(twitter: TwitterAPI, endPoint: string,
 # --------------
 # authentication
 # --------------
-# TODO
 
+
+proc oauthAuthenticate*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `oauth/authenticate` endpoint
+  return get(twitter, "oauth/authenticate", additionalParams)
+
+
+proc oauthAuthorize*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response = 
+  ## `oauth/authorize` endpoint
+  return get(twitter, "oauth/authorize", additionalParams)
+
+
+proc oauthAccessToken*(twitter: TwitterAPI, oauthToken: string, oauthVerifier: string, additionalParams: StringTableRef = nil): Response =
+  ## `oauth/access_token` endpoint
+  if additionalParams != nil:
+    additionalParams["oauth_token"] = oauthToken
+    additionalParams["oauth_verifier"] = oauthVerifier
+    return post(twitter, "oauth/access_token", additionalParams)
+  else:
+    return post(twitter, "oauth/access_token", {"oauth_token": oauthToken, "oauth_verifier": oauthVerifier}.newStringTable)
+
+
+proc oauthInvalidateToken*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `oauth/invalidate_token` endpoint
+  return post(twitter, "oauth/invalidate_token", additionalParams)
+
+
+proc oauthRequestToken*(twitter: TwitterAPI, oauthCallback: string, additionalParams: StringTableRef = nil): Response =
+  ## `oauth/request_token` endpoint
+  if additionalParams != nil:
+    additionalParams["oauth_callback"] = oauthCallback
+    return post(twitter, "oauth/request_token", additionalParams)
+  else:
+    return post(twitter, "oauth/request_token", {"oauth_callback": oauthCallback}.newStringTable)
+
+
+proc oauth2InvalidateToken*(twitter: TwitterAPI, accessToken: string, additionalParams: StringTableRef = nil): Response =
+  ## `oauth2/invalidate_token` endpoint
+  if additionalParams != nil:
+    additionalParams["access_token"] = accessToken
+    return post(twitter, "oauth2/invalidate_token", additionalParams)
+  else:
+    return post(twitter, "oauth2/invalidate_token", {"access_token": accessToken}.newStringTable)
+
+
+proc oauth2Token*(twitter: TwitterAPI, grantType: string, additionalParams: StringTableRef = nil): Response =
+  ## `oauth2/token` endpoint
+  if additionalParams != nil:
+    additionalParams["grant_type"] = grantType
+    return post(twitter, "oauth2/token", additionalParams)
+  else:
+    return post(twitter, "oauth2/token", {"grant_type": grantType}.newStringTable)
 
 # -----
 # lists

--- a/twitter.nim
+++ b/twitter.nim
@@ -131,6 +131,8 @@ proc request*(twitter: TwitterAPI, endPoint, httpMethod: string,
     return httpclient.get(client, url & "?" & path)
   elif httpMethod == "POST":
     return httpclient.post(client, url & "?" & path)
+  elif httpMethod == "DELETE":
+    return httpclient.delete(client, url & "?" & path)
 
 
 proc request*(twitter: TwitterAPI, endPoint: string, jsonBody: JsonNode = nil,
@@ -180,9 +182,7 @@ proc post*(twitter: TwitterAPI, endPoint: string,
            additionalParams: StringTableRef = nil, media: bool = false, 
            data: string): Response =
   ## Overload for post that includes binary data e.g. images / video to upload
-  if media:
-    return request(twitter, endPoint, "POST", additionalParams, requestUrl=uploadUrl, data)
-  return request(twitter, endPoint, "POST", additionalParams)
+  return request(twitter, endPoint, "POST", additionalParams, requestUrl=uploadUrl, data)
 
 
 proc post*(twitter: TwitterAPI, endPoint: string,
@@ -191,6 +191,10 @@ proc post*(twitter: TwitterAPI, endPoint: string,
     return request(twitter, endPoint, jsonBody, requestUrl=uploadUrl)
   return request(twitter, endPoint, jsonBody)
 
+
+proc delete*(twitter: TwitterAPI, endPoint: string, 
+             additionalParams: StringTableRef = nil): Response = 
+  return request(twitter, endPoint, "DELETE", additionalParams)
 
 # --------------
 # authentication

--- a/twitter.nim
+++ b/twitter.nim
@@ -219,11 +219,129 @@ proc put*(twitter: TwitterAPI, endPoint: string,
 # -----
 # TODO
 
+proc listsDestroy*(twitter: TwitterAPI, slug: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/destroy.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return post(twitter, "lists/destroy.json", additionalParams)
+  else:
+    return post(twitter, "lists/destroy.json", {"slug": slug}.newStringTable)
+
+
+proc listsDestroy*(twitter: TwitterAPI, listId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/destroy.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return post(twitter, "lists/destroy.json", additionalParams)
+  else:
+    return post(twitter, "lists/destroy.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsMembersCreate*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `lists/members/create.json` endpoint
+  # NB: this could be, I think 5, overloading procs but I have decided not to for simplicity
+  return post(twitter, "lists/members/create.json", additionalParams)
+
+
+proc listsMembersCreateAll*(twitter: TwitterAPI, listId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/members/create_all.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return post(twitter, "lists/members/create_all.json", additionalParams)
+  else:
+    return post(twitter, "lists/members/create_all.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsMembersCreateAll*(twitter: TwitterAPI, slug: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/members/create_all.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return post(twitter, "lists/members/create_all.json", additionalParams)
+  else:
+    return post(twitter, "lists/members/create_all.json", {"slug": slug}.newStringTable)
+
+
+proc listsMembersDestroy*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `lists/members/destroy.json` endpoint
+  # NB: this could be, I think 5, overloading procs but I have decided not to for simplicity
+  return post(twitter, "lists/members/destroy.json", additionalParams)
+
+
+proc listsMembersDestroyAll*(twitter: TwitterAPI, listId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/members/destroy_all.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return post(twitter, "lists/members/destroy_all.json", additionalParams)
+  else:
+    return post(twitter, "lists/members/destroy_all.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsMembersDestroyAll*(twitter: TwitterAPI, slug: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/members/destroy_all.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return post(twitter, "lists/members/destroy_all.json", additionalParams)
+  else:
+    return post(twitter, "lists/members/destroy_all.json", {"slug": slug}.newStringTable)
+
+
+proc listsSubscribersCreate*(twitter: TwitterAPI, slug: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscribers/create.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return post(twitter, "lists/subscribers/create.json", additionalParams)
+  else:
+    return post(twitter, "lists/subscribers/create.json", {"slug": slug}.newStringTable)
+
+
+proc listsSubscribersCreate*(twitter: TwitterAPI, listId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscribers/create.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return post(twitter, "lists/subscribers/create.json", additionalParams)
+  else:
+    return post(twitter, "lists/subscribers/create.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsSubscribersDestroy*(twitter: TwitterAPI, slug: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscribers/destroy.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return post(twitter, "lists/subscribers/destroy.json", additionalParams)
+  else:
+    return post(twitter, "lists/subscribers/destroy.json", {"slug": slug}.newStringTable)
+
+
+proc listsSubscribersDestroy*(twitter: TwitterAPI, listId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscribers/destroy.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return post(twitter, "lists/subscribers/destroy.json", additionalParams)
+  else:
+    return post(twitter, "lists/subscribers/destroy.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsUpdate*(twitter: TwitterAPI, slug: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/update.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return post(twitter, "lists/update.json", additionalParams)
+  else:
+    return post(twitter, "lists/update.json", {"slug": slug}.newStringTable)
+
+
+proc listsUpdate*(twitter: TwitterAPI, listId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/update.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return post(twitter, "lists/update.json", additionalParams)
+  else:
+    return post(twitter, "lists/update.json", {"list_id": $listId}.newStringTable)
+
 
 # ---------------------------------
 # followers / friends / friendships
 # ---------------------------------
-# TODO
 
 proc followersIds*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
   ## `followers/ids.json` endpoint for screen name

--- a/twitter.nim
+++ b/twitter.nim
@@ -12,7 +12,7 @@ import json
 
 const baseUrl = "https://api.twitter.com/1.1/"
 const uploadUrl = "https://upload.twitter.com/1.1/"
-const clientUserAgent = "twitter.nim/0.3.0"
+const clientUserAgent = "twitter.nim/1.0.0"
 
 
 type
@@ -190,43 +190,44 @@ proc post*(twitter: TwitterAPI, endPoint: string,
     return request(twitter, endPoint, jsonBody, requestUrl=uploadUrl)
   return request(twitter, endPoint, jsonBody)
 
+
 proc statusesUpdate*(twitter: TwitterAPI,
                     additionalParams: StringTableRef = nil): Response =
   ## `statuses/update.json` endpoint
   return post(twitter, "statuses/update.json", additionalParams)
 
 
-proc userTimeline*(twitter: TwitterAPI,
+proc statusesUserTimeline*(twitter: TwitterAPI,
                    additionalParams: StringTableRef = nil): Response =
   ## `statuses/user_timeline.json` endpoint
   return get(twitter, "statuses/user_timeline.json", additionalParams)
 
 
-proc homeTimeline*(twitter: TwitterAPI,
+proc statusesHomeTimeline*(twitter: TwitterAPI,
                    additionalParams: StringTableRef = nil): Response =
   ## `statuses/home_timeline.json` endpoint
   return get(twitter, "statuses/home_timeline.json", additionalParams)
 
 
-proc mentionsTimeline*(twitter: TwitterAPI,
+proc statusesMentionsTimeline*(twitter: TwitterAPI,
                        additionalParams: StringTableRef = nil): Response =
   ## `statuses/mentions_timeline.json` endpoint
   return get(twitter, "statuses/mentions_timeline.json", additionalParams)
 
 
-proc retweetsOfMe*(twitter: TwitterAPI,
+proc statusesRetweetsOfMe*(twitter: TwitterAPI,
                    additionalParams: StringTableRef = nil): Response =
   ## `statuses/retweets_of_me.json` endpoint
   return get(twitter, "statuses/retweets_of_me.json", additionalParams)
 
 
-proc user*(twitter: TwitterAPI,
+proc accountVerifyCredentials*(twitter: TwitterAPI,
            additionalParams: StringTableRef = nil): Response =
   ## `account/verify_credentials.json` endpoint
   return get(twitter, "account/verify_credentials.json", additionalParams)
 
 
-proc user*(twitter: TwitterAPI, screenName: string,
+proc usersShow*(twitter: TwitterAPI, screenName: string,
            additionalParams: StringTableRef = nil): Response =
   ## `users/show.json` endpoint for screen names (@username)
   if additionalParams != nil:
@@ -236,7 +237,7 @@ proc user*(twitter: TwitterAPI, screenName: string,
     return get(twitter, "users/show.json", {"screen_name": screenName}.newStringTable)
 
 
-proc user*(twitter: TwitterAPI, userId: int32,
+proc usersShow*(twitter: TwitterAPI, userId: int32,
            additionalParams: StringTableRef = nil): Response =
   ## `users/show.json` endpoint for user id (e.g. `783214 => @twitter`)
   if additionalParams != nil:
@@ -245,17 +246,6 @@ proc user*(twitter: TwitterAPI, userId: int32,
   else:
     return get(twitter, "users/show.json", {"user_id": $userId}.newStringTable)
 
-
-proc uploadFile*(twitter: TwitterAPI, filename: string,
-                 mediaType: string, additionalParams: StringTableRef = nil): Response =
-  ## Upload a file from a filename 
-  ##
-  ## mediaType takes these arguments: `amplify_video, tweet_gif, tweet_image, tweet_video`
-  # This is a bit 'higher level' than the rest but IMO is routine enough and simple enough to make it useful
-  var ubody = additionalParams
-  ubody["media_type"] = mediaType
-  let data = $ readFile(filename)
-  return post(twitter, "media/upload.json", ubody, true, data)
 
 proc mediaUploadInit*(twitter: TwitterAPI, 
                       mediaType: string, totalBytes: string, 
@@ -346,6 +336,18 @@ proc mediaSubtitlesDelete*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
   ##
   ## Docs: https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-subtitles-create
   return post(twitter, "media/subtitles/delete.json", jsonBody, media=true)
+
+
+proc uploadFile*(twitter: TwitterAPI, filename: string,
+                 mediaType: string, additionalParams: StringTableRef = nil): Response =
+  ## Upload a file from a filename 
+  ##
+  ## mediaType takes these arguments: `amplify_video, tweet_gif, tweet_image, tweet_video`
+  # This is a bit 'higher level' than the rest but IMO is routine enough and simple enough to make it useful
+  var ubody = additionalParams
+  ubody["media_type"] = mediaType
+  let data = $ readFile(filename)
+  return post(twitter, "media/upload.json", ubody, true, data)
 
 
 template callAPI*(twitter: TwitterAPI, api: untyped,

--- a/twitter.nim
+++ b/twitter.nim
@@ -217,7 +217,191 @@ proc put*(twitter: TwitterAPI, endPoint: string,
 # -----
 # lists
 # -----
-# TODO
+proc listsList*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/list.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "lists/list.json", additionalParams)
+  else:
+    return get(twitter, "lists/list.json", {"screen_name": screenName}.newStringTable)
+
+
+proc listsList*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/list.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "lists/list.json", additionalParams)
+  else:
+    return get(twitter, "lists/list.json", {"user_id": $userId}.newStringTable)
+
+
+proc listsMembers*(twitter: TwitterAPI, slug: string,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/members.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return get(twitter, "lists/members.json", additionalParams)
+  else:
+    return get(twitter, "lists/members.json", {"slug": slug}.newStringTable)
+
+
+proc listsMembers*(twitter: TwitterAPI, listId: int,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/members.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return get(twitter, "lists/members.json", additionalParams)
+  else:
+    return get(twitter, "lists/members.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsMembersShow*(twitter: TwitterAPI, slug: string,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/members/show.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return get(twitter, "lists/members/show.json", additionalParams)
+  else:
+    return get(twitter, "lists/members/show.json", {"slug": slug}.newStringTable)
+
+
+proc listsMembersShow*(twitter: TwitterAPI, listId: int,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/members/show.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return get(twitter, "lists/members/show.json", additionalParams)
+  else:
+    return get(twitter, "lists/members/show.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsMemberships*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/memberships.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "lists/memberships.json", additionalParams)
+  else:
+    return get(twitter, "lists/memberships.json", {"screen_name": screenName}.newStringTable)
+
+
+proc listsMemberships*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/memberships.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "lists/memberships.json", additionalParams)
+  else:
+    return get(twitter, "lists/memberships.json", {"user_id": $userId}.newStringTable)
+
+
+proc listsOwnerships*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/ownerships.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "lists/ownerships.json", additionalParams)
+  else:
+    return get(twitter, "lists/ownerships.json", {"screen_name": screenName}.newStringTable)
+
+
+proc listsOwnerships*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/ownerships.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "lists/ownerships.json", additionalParams)
+  else:
+    return get(twitter, "lists/ownerships.json", {"user_id": $userId}.newStringTable)
+
+
+proc listsShow*(twitter: TwitterAPI, slug: string,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/show.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return get(twitter, "lists/show.json", additionalParams)
+  else:
+    return get(twitter, "lists/show.json", {"slug": slug}.newStringTable)
+
+
+proc listsShow*(twitter: TwitterAPI, listId: int,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/show.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return get(twitter, "lists/show.json", additionalParams)
+  else:
+    return get(twitter, "lists/show.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsStatuses*(twitter: TwitterAPI, slug: string,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/statuses.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return get(twitter, "lists/statuses.json", additionalParams)
+  else:
+    return get(twitter, "lists/statuses.json", {"slug": slug}.newStringTable)
+
+
+proc listsStatuses*(twitter: TwitterAPI, listId: int,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/statuses.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return get(twitter, "lists/statuses.json", additionalParams)
+  else:
+    return get(twitter, "lists/statuses.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsSubscribers*(twitter: TwitterAPI, slug: string,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscribers.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return get(twitter, "lists/subscribers.json", additionalParams)
+  else:
+    return get(twitter, "lists/subscribers.json", {"slug": slug}.newStringTable)
+
+
+proc listsSubscribers*(twitter: TwitterAPI, listId: int,  additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscribers.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return get(twitter, "lists/subscribers.json", additionalParams)
+  else:
+    return get(twitter, "lists/subscribers.json", {"list_id": $listId}.newStringTable)
+
+
+proc listsSubscribersShow*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscribers/show.json` endpoint
+  # NB: this could be, I think 4, overloading procs but I have decided not to for simplicity
+  return get(twitter, "lists/subscribers/show.json", additionalParams)
+
+
+proc listsSubscriptions*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscriptions.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "lists/subscriptions.json", additionalParams)
+  else:
+    return get(twitter, "lists/subscriptions.json", {"screen_name": screenName}.newStringTable)
+
+
+proc listsSubscriptions*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/subscriptions.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "lists/subscriptions.json", additionalParams)
+  else:
+    return get(twitter, "lists/subscriptions.json", {"user_id": $userId}.newStringTable)
+
+
+proc listsCreate*(twitter: TwitterAPI, slug: string, additionalParams: StringTableRef = nil): Response =
+  ## `lists/create.json` endpoint for slug
+  if additionalParams != nil:
+    additionalParams["slug"] = slug
+    return post(twitter, "lists/create.json", additionalParams)
+  else:
+    return post(twitter, "lists/create.json", {"slug": slug}.newStringTable)
+
+
+proc listsCreate*(twitter: TwitterAPI, listId: int, additionalParams: StringTableRef = nil): Response =
+  ## `lists/create.json` endpoint for list id
+  if additionalParams != nil:
+    additionalParams["list_id"] = $listId
+    return post(twitter, "lists/create.json", additionalParams)
+  else:
+    return post(twitter, "lists/create.json", {"list_id": $listId}.newStringTable)
+
 
 proc listsDestroy*(twitter: TwitterAPI, slug: string, additionalParams: StringTableRef = nil): Response =
   ## `lists/destroy.json` endpoint for slug
@@ -239,7 +423,7 @@ proc listsDestroy*(twitter: TwitterAPI, listId: int, additionalParams: StringTab
 
 proc listsMembersCreate*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
   ## `lists/members/create.json` endpoint
-  # NB: this could be, I think 5, overloading procs but I have decided not to for simplicity
+  # NB: this could be, I think 4, overloading procs but I have decided not to for simplicity
   return post(twitter, "lists/members/create.json", additionalParams)
 
 
@@ -263,7 +447,7 @@ proc listsMembersCreateAll*(twitter: TwitterAPI, slug: string, additionalParams:
 
 proc listsMembersDestroy*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
   ## `lists/members/destroy.json` endpoint
-  # NB: this could be, I think 5, overloading procs but I have decided not to for simplicity
+  # NB: this could be, I think 4, overloading procs but I have decided not to for simplicity
   return post(twitter, "lists/members/destroy.json", additionalParams)
 
 

--- a/twitter.nim
+++ b/twitter.nim
@@ -184,12 +184,90 @@ proc post*(twitter: TwitterAPI, endPoint: string,
     return request(twitter, endPoint, "POST", additionalParams, requestUrl=uploadUrl, data)
   return request(twitter, endPoint, "POST", additionalParams)
 
+
 proc post*(twitter: TwitterAPI, endPoint: string,
            jsonBody: JsonNode, media: bool = false): Response =
   if media:
     return request(twitter, endPoint, jsonBody, requestUrl=uploadUrl)
   return request(twitter, endPoint, jsonBody)
 
+
+# --------------
+# authentication
+# --------------
+# TODO
+
+
+# -----
+# lists
+# -----
+# TODO
+
+
+# ---------------------------------
+# followers / friends / friendships
+# ---------------------------------
+# TODO
+
+
+# -----
+# users
+# -----
+# TODO
+
+
+proc usersShow*(twitter: TwitterAPI, screenName: string,
+           additionalParams: StringTableRef = nil): Response =
+  ## `users/show.json` endpoint for screen names (@username)
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return get(twitter, "users/show.json", additionalParams)
+  else:
+    return get(twitter, "users/show.json", {"screen_name": screenName}.newStringTable)
+
+
+proc usersShow*(twitter: TwitterAPI, userId: int32,
+           additionalParams: StringTableRef = nil): Response =
+  ## `users/show.json` endpoint for user id (e.g. `783214 => @twitter`)
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "users/show.json", additionalParams)
+  else:
+    return get(twitter, "users/show.json", {"user_id": $userId}.newStringTable)
+
+
+# -------
+# account
+# -------
+# TODO
+
+proc accountVerifyCredentials*(twitter: TwitterAPI,
+           additionalParams: StringTableRef = nil): Response =
+  ## `account/verify_credentials.json` endpoint
+  return get(twitter, "account/verify_credentials.json", additionalParams)
+
+# --------------
+# saved_searches
+# --------------
+#TODO
+
+
+# --------------
+# blocks / mutes
+# --------------
+#TODO
+
+
+# -----------
+# collections
+# -----------
+# TODO
+
+
+# --------
+# statuses
+# --------
+# TODO
 
 proc statusesUpdate*(twitter: TwitterAPI,
                     additionalParams: StringTableRef = nil): Response =
@@ -221,31 +299,33 @@ proc statusesRetweetsOfMe*(twitter: TwitterAPI,
   return get(twitter, "statuses/retweets_of_me.json", additionalParams)
 
 
-proc accountVerifyCredentials*(twitter: TwitterAPI,
-           additionalParams: StringTableRef = nil): Response =
-  ## `account/verify_credentials.json` endpoint
-  return get(twitter, "account/verify_credentials.json", additionalParams)
+# ---------
+# favorites
+# ---------
+# TODO
 
 
-proc usersShow*(twitter: TwitterAPI, screenName: string,
-           additionalParams: StringTableRef = nil): Response =
-  ## `users/show.json` endpoint for screen names (@username)
-  if additionalParams != nil:
-    additionalParams["screen_name"] = screenName
-    return get(twitter, "users/show.json", additionalParams)
-  else:
-    return get(twitter, "users/show.json", {"screen_name": screenName}.newStringTable)
+# ----------
+# compliance
+# ----------
+# TODO
 
 
-proc usersShow*(twitter: TwitterAPI, userId: int32,
-           additionalParams: StringTableRef = nil): Response =
-  ## `users/show.json` endpoint for user id (e.g. `783214 => @twitter`)
-  if additionalParams != nil:
-    additionalParams["user_id"] = $userId
-    return get(twitter, "users/show.json", additionalParams)
-  else:
-    return get(twitter, "users/show.json", {"user_id": $userId}.newStringTable)
+# ---------------
+# custom_profiles
+# ---------------
+# TODO
 
+
+# ---------------
+# direct_messages
+# ---------------
+# TODO
+
+
+# -----
+# media
+# -----
 
 proc mediaUploadInit*(twitter: TwitterAPI, 
                       mediaType: string, totalBytes: string, 
@@ -337,6 +417,29 @@ proc mediaSubtitlesDelete*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
   ## Docs: https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-subtitles-create
   return post(twitter, "media/subtitles/delete.json", jsonBody, media=true)
 
+
+# ------
+# trends
+# ------
+# TODO
+
+
+# ---
+# geo
+# ---
+# TODO
+
+
+# --------
+# insights
+# --------
+# TODO
+
+
+# -------
+# utility
+# -------
+# General-use functions that might be useful without being too compicated
 
 proc uploadFile*(twitter: TwitterAPI, filename: string,
                  mediaType: string, additionalParams: StringTableRef = nil): Response =

--- a/twitter.nim
+++ b/twitter.nim
@@ -433,8 +433,22 @@ proc mediaSubtitlesDelete*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
 # --------
 # insights
 # --------
-# TODO
 
+
+proc insightsEngagementTotals*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
+  ## `insights/enagement/totals.json` endpoint
+  return post(twitter, "insights/enagement/totals.json", jsonBody)
+
+
+proc insightsEngagementHistorical*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
+  ## `insights/enagement/historical.json` endpoint
+  return post(twitter, "insights/enagement/historical.json", jsonBody)
+
+
+proc insightsEngagement28h*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
+  ## `insights/enagement/28h.json` endpoint
+  return post(twitter, "insights/enagement/28h.json", jsonBody)
+  
 
 # -------
 # utility

--- a/twitter.nim
+++ b/twitter.nim
@@ -427,7 +427,27 @@ proc mediaSubtitlesDelete*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
 # ---
 # geo
 # ---
-# TODO
+
+
+proc geoId*(twitter:TwitterAPI, id: string, additionalParams: StringTableRef = nil): Response =
+  ## `geo/id/:place_id.json` endpoint
+  return get(twitter, "geo/id/" & id & ".json", additionalParams)
+
+
+proc geoReverseGeocode*(twitter:TwitterAPI, lat: float, lon: float,
+                        additionalParams: StringTableRef = nil): Response =
+  ## `geo/reverse_geocode.json` endpoint
+  if additionalParams != nil:
+    additionalParams["lat"] = $ lat
+    additionalParams["lon"] = $ lon
+    return get(twitter, "geo/reverse_geocode.json", additionalParams)
+  else:
+    return get(twitter, "geo/reverse_geocode.json", {"lat": $lat, "lon": $lon}.newStringTable)
+
+
+proc geoSearch*(twitter:TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `geo/search.json` endpoint
+  return get(twitter, "geo/search.json", additionalParams)
 
 
 # --------

--- a/twitter.nim
+++ b/twitter.nim
@@ -242,7 +242,7 @@ proc usersShow*(twitter: TwitterAPI, screenName: string,
     return get(twitter, "users/show.json", {"screen_name": screenName}.newStringTable)
 
 
-proc usersShow*(twitter: TwitterAPI, userId: int32,
+proc usersShow*(twitter: TwitterAPI, userId: int,
            additionalParams: StringTableRef = nil): Response =
   ## `users/show.json` endpoint for user id (e.g. `783214 => @twitter`)
   if additionalParams != nil:
@@ -250,6 +250,24 @@ proc usersShow*(twitter: TwitterAPI, userId: int32,
     return get(twitter, "users/show.json", additionalParams)
   else:
     return get(twitter, "users/show.json", {"user_id": $userId}.newStringTable)
+
+
+proc usersReportSpam*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `users/report_spam.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["user_id"] = $screenName
+    return get(twitter, "users/report_spam.json", additionalParams)
+  else:
+    return get(twitter, "users/report_spam.json", {"screen_name": $screenName}.newStringTable)
+
+
+proc usersReportSpam*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `users/report_spam.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return get(twitter, "users/report_spam.json", additionalParams)
+  else:
+    return get(twitter, "users/report_spam.json", {"user_id": $userId}.newStringTable)
 
 
 # -------
@@ -274,10 +292,101 @@ proc accountVerifyCredentials*(twitter: TwitterAPI,
 #TODO
 
 
+proc blocksIds*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `blocks/ids.json` endpoint
+  return get(twitter, "blocks/ids.json", additionalParams)
+
+
+proc blocksList*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `blocks/list.json` endpoint
+  return get(twitter, "blocks/list.json", additionalParams)
+
+
+proc mutesUsersIds*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `mutes/users/ids.json` endpoint
+  return get(twitter, "mutes/users/ids.json", additionalParams)
+
+
+proc mutesUsersList*(twitter: TwitterAPI, additionalParams: StringTableRef = nil): Response =
+  ## `mutes/users/list.json` endpoint
+  return get(twitter, "mutes/users/list.json", additionalParams)
+
+
+proc blocksCreate*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  # `blocks/create.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["user_id"] = $screenName
+    return post(twitter, "blocks/create.json", additionalParams)
+  else:
+    return post(twitter, "blocks/create.json", {"screen_name": $screenName}.newStringTable)
+
+
+proc blocksCreate*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  # `blocks/create.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return post(twitter, "blocks/create.json", additionalParams)
+  else:
+    return post(twitter, "blocks/create.json", {"user_id": $userId}.newStringTable)
+
+
+proc blocksDestroy*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  # `blocks/destroy.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["user_id"] = $screenName
+    return post(twitter, "blocks/destroy.json", additionalParams)
+  else:
+    return post(twitter, "blocks/destroy.json", {"screen_name": $screenName}.newStringTable)
+
+
+proc blocksDestroy*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  # `blocks/destroy.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return post(twitter, "blocks/destroy.json", additionalParams)
+  else:
+    return post(twitter, "blocks/destroy.json", {"user_id": $userId}.newStringTable)
+
+
+proc mutesUsersCreate*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  # `mutes/users/create.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["user_id"] = $screenName
+    return post(twitter, "mutes/users/create.json", additionalParams)
+  else:
+    return post(twitter, "mutes/users/create.json", {"screen_name": $screenName}.newStringTable)
+
+
+proc mutesUsersCreate*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  # `mutes/users/create.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return post(twitter, "mutes/users/create.json", additionalParams)
+  else:
+    return post(twitter, "mutes/users/create.json", {"user_id": $userId}.newStringTable)
+
+
+proc mutesUsersDestroy*(twitter: TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  # `mutes/users/destroy.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["user_id"] = $screenName
+    return post(twitter, "mutes/users/destroy.json", additionalParams)
+  else:
+    return post(twitter, "mutes/users/destroy.json", {"screen_name": $screenName}.newStringTable)
+
+
+proc mutesUsersDestroy*(twitter: TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  # `mutes/users/destroy.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return post(twitter, "mutes/users/destroy.json", additionalParams)
+  else:
+    return post(twitter, "mutes/users/destroy.json", {"user_id": $userId}.newStringTable)
+
+
 # -----------
 # collections
 # -----------
-# TODO
 
 
 proc collectionsEntries*(twitter:TwitterAPI, id: string, additionalParams: StringTableRef = nil): Response =
@@ -487,6 +596,7 @@ proc statusesSample*(twitter: TwitterAPI, additionalParams: StringTableRef = nil
   ## `statuses/sample.json` endpoint
   return get(twitter, "statuses/sample.json", additionalParams)
 
+
 # ---------
 # favorites
 # ---------
@@ -513,6 +623,7 @@ proc favoritesDestroy*(twitter: TwitterAPI, id: int, additionalParams: StringTab
     return post(twitter, "favorites/destroy.json", additionalParams)
   else:
     return post(twitter, "favorites/destroy.json", {"id": $id}.newStringTable)
+
 
 # ------
 # search
@@ -669,6 +780,7 @@ proc directMessagesWelcomeMessagesNew*(twitter: TwitterAPI, jsonBody: JsonNode):
 proc directMessagesWelcomeMessagesRulesNew*(twitter: TwitterAPI, jsonBody: JsonNode): Response =
   ## `direct_messages/welcome_messages/rules/new.json` endpoint
   return post(twitter, "direct_messages/welcome_messages/rules/new.json", jsonBody)
+
 
 # -----
 # media

--- a/twitter.nim
+++ b/twitter.nim
@@ -229,7 +229,34 @@ proc put*(twitter: TwitterAPI, endPoint: string,
 # -----
 # users
 # -----
-# TODO
+
+
+proc usersLookup*(twitter:TwitterAPI, userId: int, additionalParams: StringTableRef = nil): Response =
+  ## `users/lookup.json` endpoint for user id
+  if additionalParams != nil:
+    additionalParams["user_id"] = $userId
+    return post(twitter, "users/lookup.json", additionalParams)
+  else:
+    return post(twitter, "users/lookup.json", {"user_id": $userId}.newStringTable)
+
+
+proc usersLookup*(twitter:TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
+  ## `users/lookup.json` endpoint for screen name
+  if additionalParams != nil:
+    additionalParams["screen_name"] = screenName
+    return post(twitter, "users/lookup.json", additionalParams)
+  else:
+    return post(twitter, "users/lookup.json", {"screen_name": screenName}.newStringTable)
+
+
+proc usersSearch*(twitter:TwitterAPI, q: string, additionalParams: StringTableRef = nil): Response =
+  ## `users/search.json` endpoint
+  if additionalParams != nil:
+    additionalParams["q"] = q
+    return get(twitter, "users/search.json", additionalParams)
+  else:
+    return get(twitter, "users/search.json", {"q": q}.newStringTable)
+
 
 proc usersProfileBanner*(twitter:TwitterAPI, screenName: string, additionalParams: StringTableRef = nil): Response =
   ## `users/profile_banner.json` endpoint
@@ -290,7 +317,6 @@ proc usersReportSpam*(twitter: TwitterAPI, userId: int, additionalParams: String
 # -------
 # account
 # -------
-# TODO
 
 
 proc accountSettings*(twitter:TwitterAPI, additionalParams: StringTableRef = nil): Response =

--- a/twitter.nim
+++ b/twitter.nim
@@ -1331,10 +1331,14 @@ proc directMessagesIndicateTyping*(twitter: TwitterAPI, jsonBody: JsonNode): Res
   return post(twitter, "direct_messages/indicate_typing.json", jsonBody)
 
 
-#TODO TEST THIS
-proc directMessagesMarkRead*(twitter: TwitterAPI, jsonBody: JsonNode): Response = 
+proc directMessagesMarkRead*(twitter: TwitterAPI, lastReadEventId: int, recipientId: int, additionalParams: StringTableRef = nil): Response = 
   ## `direct_messages/mark_read.json` endpoint
-  return post(twitter, "direct_messages/mark_read.json", jsonBody)
+  if additionalParams != nil:
+    additionalParams["last_read_event_id"] = $lastReadEventId
+    additionalParams["recipient_id"] = $recipientId
+    return post(twitter, "direct_messages/mark_read.json", additionalParams)
+  else:
+    return post(twitter, "direct_messages/mark_read.json", {"last_read_event_id": $lastReadEventId, "recipient_id": $recipientId}.newStringTable)
 
 
 proc directMessagesWelcomeMessagesDestroy*(twitter: TwitterAPI, id: int,

--- a/twitter.nimble
+++ b/twitter.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.3.0"
+version = "1.0.0"
 author = "snus-kin"
 description = "A twitter API wrapper for Nim."
 license = "MIT"


### PR DESCRIPTION
Full support for all endpoints specified in the API Index Reference.

- Includes new methods for `PUT` and `DELETE`
- Support for the `publish.twitter.com` domain for `oembed` API

The `twitter.nim` file is vaguely in the order of the API Index, with comment headings to break up different endpoints, I have also annotated each proc with their endpoints for ease of finding. Some of the API docs on twitter are badly written and might have things like `.format` instead of `.json` which I assume was a templating error, I have tested these and corrected them in the comments.

NB: method `user()` which accessed multiple endpoints has been replaced with relevant more specific proc names. i.e. this might not be backwards-compatible if you relied on those procs.